### PR TITLE
 rpc:call/4, rpc:cast/4, erpc:cast/4 from Erlang to Ergo does not work

### DIFF
--- a/node/core.go
+++ b/node/core.go
@@ -894,7 +894,7 @@ func (c *core) RouteSpawnRequest(node string, behaviorName string, request gen.R
 
 		// spawn new process
 		process_opts := processOptions{}
-		process_opts.Env = map[gen.EnvKey]interface{}{EnvKeyRemoteSpawn: request.Options}
+		process_opts.Env = map[gen.EnvKey]interface{}{EnvKeyRemoteSpawn: request.Options, "ergo:RemoteSpawnRequest": request}
 		process, err_spawn := c.spawn(request.Options.Name, process_opts, b.Behavior, args...)
 
 		// reply

--- a/proto/dist/proto.go
+++ b/proto/dist/proto.go
@@ -1322,8 +1322,12 @@ func (dc *distConnection) handleMessage(message *distMessage) (err error) {
 					}
 				}
 
-				if registerName == "" && module == etf.Atom("erpc") {
-					registerName = "erpc"
+				if registerName == "" {
+					if module == etf.Atom("erpc") {
+						registerName = "erpc"
+					} else {
+						return fmt.Errorf("malformed spawn request")
+					}
 				}
 
 				spawnRequestOptions := gen.RemoteSpawnOptions{

--- a/proto/dist/proto.go
+++ b/proto/dist/proto.go
@@ -1297,12 +1297,11 @@ func (dc *distConnection) handleMessage(message *distMessage) (err error) {
 				registerName := ""
 				for _, option := range t.Element(6).(etf.List) {
 					name, ok := option.(etf.Tuple)
-					if !ok || len(name) != 2 {
-						return fmt.Errorf("malformed spawn request")
-					}
-					switch name.Element(1) {
-					case etf.Atom("name"):
-						registerName = string(name.Element(2).(etf.Atom))
+					if ok || len(name) == 2 {
+						switch name.Element(1) {
+						case etf.Atom("name"):
+							registerName = string(name.Element(2).(etf.Atom))
+						}
 					}
 				}
 
@@ -1321,6 +1320,10 @@ func (dc *distConnection) handleMessage(message *distMessage) (err error) {
 					for i := range []byte(str) {
 						args = append(args, str[i])
 					}
+				}
+
+				if registerName == "" && module == etf.Atom("erpc") {
+					registerName = "erpc"
 				}
 
 				spawnRequestOptions := gen.RemoteSpawnOptions{

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package ergo
 
 const (
-	Version           = "2.2.0" // Ergo Framework version
+	Version           = "2.2.1" // Ergo Framework version
 	VersionPrefix     = "ergo"  // Prefix using for the full version name
 	VersionOTP    int = 24      // Erlang version support
 )


### PR DESCRIPTION
Erlang project has rpc:call/4, rpc:cast/4, need ergo to be compatible。
I tried to fix the bug that rpc:call/4, rpc:cast/4 from Erlang to Ergo does not work.
https://github.com/leonlee2013/ergo/commit/a98e83493f99f4682ce93e19a5e3674d43e02936
https://github.com/leonlee2013/ergo/commit/d9db4bc2ed7677767f91622d98967b211151f5ad

**Here is the test code**：

```go
package main

import (
	"flag"
	"fmt"

	"github.com/ergo-services/ergo"
	"github.com/ergo-services/ergo/etf"
	"github.com/ergo-services/ergo/node"
)

var (
	ServerName string
	NodeName   string
	Cookie     string
)

func init() {
	flag.StringVar(&ServerName, "server", "example", "server process name")
	flag.StringVar(&NodeName, "name", "go_node1@127.0.0.1", "node name")
	flag.StringVar(&Cookie, "cookie", "go_erlang_cookie", "cookie for interaction with erlang cluster")
}

func main() {
	flag.Parse()

	fmt.Println("")
	fmt.Println("to stop press Ctrl-C")
	fmt.Println("")

	node, err := ergo.StartNode(NodeName, Cookie, node.Options{})
	if err != nil {
		panic(err)
	}

	testFun1 := func(a ...etf.Term) etf.Term {
		fmt.Printf("go handle --->>> %#v\n", a)
		return a[len(a)-1]
	}
	if e := node.ProvideRPC("testMod", "testFun", testFun1); e != nil {
		panic(err)
	}

	fmt.Println("Start erlang node with the command below:")
	fmt.Printf("    $ erl -name %s -setcookie %s\n\n", "erl-"+node.Name(), Cookie)

	fmt.Println("----- to make call request from 'erl'-shell:")
	fmt.Printf("gen_server:call({%s,'%s'}, hi).\n", ServerName, NodeName)
	fmt.Printf("gen_server:call({%s,'%s'}, {echo, 1,2,3}).\n", ServerName, NodeName)
	fmt.Println("----- to send cast message from 'erl'-shell:")
	fmt.Printf("gen_server:cast({%s,'%s'}, {cast, 1,2,3}).\n", ServerName, NodeName)
	fmt.Println("----- send atom 'stop' to stop server :")
	fmt.Printf("gen_server:cast({%s,'%s'}, stop).\n", ServerName, NodeName)

	node.Wait()
}
```
**Erlang input and output:**
```erlang
(erl-go_node1@127.0.0.1)50> rpc:call('go_node1@127.0.0.1', testMod, testFun, [a, b,111]).
111
(erl-go_node1@127.0.0.1)51> rpc:cast('go_node1@127.0.0.1', testMod, testFun, [a, b,111]).
true
```
**Log output of Go**
```go
go handle --->>> []etf.Term{"a", "b", 111}
go handle --->>> []etf.Term{"a", "b", 111}
```

Looking forward to your review and merge！！！