### PR TITLE
rpc:cast/4 from Erlang/OTP24 to Ergo does not work

### DIFF
--- a/apps/erlang/rex.go
+++ b/apps/erlang/rex.go
@@ -80,6 +80,53 @@ func (r *rex) HandleCall(process *gen.ServerProcess, from gen.ServerFrom, messag
 	return reply, gen.ServerStatusOK
 }
 
+// HandleCast
+func (r *rex) HandleCast(process *gen.ServerProcess, message etf.Term) gen.ServerStatus {
+	lib.Log("REX: HandleCast: %#v", message)
+	switch m := message.(type) {
+	case etf.Tuple:
+		//etf.Tuple{"cast", "observer_backend", "sys_info",
+		//           etf.List{}, etf.Pid{Node:"erl-examplenode@127.0.0.1", Id:0x46, Serial:0x0, Creation:0x2}}
+		switch m.Element(1) {
+		case etf.Atom("cast"):
+			module := m.Element(2).(etf.Atom)
+			function := m.Element(3).(etf.Atom)
+			args := m.Element(4).(etf.List)
+			reply := r.handleRPC(process, module, function, args)
+			if reply != nil {
+				checkErrAndWarning(reply)
+				return gen.ServerStatusOK
+			}
+
+			to := gen.ProcessID{Name: string(module), Node: process.NodeName()}
+			m := etf.Tuple{m.Element(3), m.Element(4)}
+			err := process.Cast(to, m)
+			if err != nil {
+				reply = etf.Term(etf.Tuple{etf.Atom("error"), err})
+				checkErrAndWarning(reply)
+			}
+			return gen.ServerStatusOK
+
+		}
+	}
+
+	reply := etf.Term(etf.Tuple{etf.Atom("badrpc"), etf.Atom("unknown")})
+	checkErrAndWarning(reply)
+	return gen.ServerStatusOK
+}
+
+func checkErrAndWarning(reply interface{}) {
+	switch rep := reply.(type) {
+	case etf.Tuple:
+		switch rep.Element(1) {
+		case etf.Atom("badrpc"):
+			lib.Warning("badrpc: %s", rep)
+		case etf.Atom("error"):
+			lib.Warning("error: %s", rep)
+		}
+	}
+}
+
 // HandleInfo
 func (r *rex) HandleInfo(process *gen.ServerProcess, message etf.Term) gen.ServerStatus {
 	// add this handler to suppres any messages from erlang


### PR DESCRIPTION
Erlang project has rpc:cast/4 which needs to be compatible with ergo.
**Here is the test code**：

```go
package main

import (
	"flag"
	"fmt"

	"github.com/ergo-services/ergo"
	"github.com/ergo-services/ergo/etf"
	"github.com/ergo-services/ergo/node"
)

var (
	ServerName string
	NodeName   string
	Cookie     string
)

func init() {
	flag.StringVar(&ServerName, "server", "example", "server process name")
	flag.StringVar(&NodeName, "name", "go_node1@127.0.0.1", "node name")
	flag.StringVar(&Cookie, "cookie", "go_erlang_cookie", "cookie for interaction with erlang cluster")
}

func main() {
	flag.Parse()

	fmt.Println("")
	fmt.Println("to stop press Ctrl-C")
	fmt.Println("")

	node, err := ergo.StartNode(NodeName, Cookie, node.Options{})
	if err != nil {
		panic(err)
	}

	testFun1 := func(a ...etf.Term) etf.Term {
		fmt.Printf("go handle --->>> %#v\n", a)
		return a[len(a)-1]
	}
	if e := node.ProvideRPC("testMod", "testFun", testFun1); e != nil {
		panic(err)
	}

	fmt.Println("Start erlang node with the command below:")
	fmt.Printf("    $ erl -name %s -setcookie %s\n\n", "erl-"+node.Name(), Cookie)

	node.Wait()
}
```
**Before fixing the bug of rpc:call/4**

```bash
#Erlang input and output:
(erl-go_node1@127.0.0.1)51> rpc:cast('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).
true

#Log output of Go
2022/12/07 21:23:02 WARNING! Server [rex] HandleCast: unhandled message etf.Tuple{"cast", "testMod", "testFun", etf.List{"a", "hello", 111}, etf.Pid{Node:"erl-go_node1@127.0.0.1", ID:0x48, Creation:0x638455dd}}
```
**After fixing the bug of rpc:call/4**

```bash
#Erlang input and output:
(erl-go_node1@127.0.0.1)51> rpc:cast('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).
true

#Log output of Go
go handle --->>> []etf.Term{"a", "hello", 111}
```