### PR TITLE
erpc:call/4 from Erlang/OTP24 to Ergo does not work

### DIFF
--- a/node/core.go
+++ b/node/core.go
@@ -894,7 +894,7 @@ func (c *core) RouteSpawnRequest(node string, behaviorName string, request gen.R
 
 		// spawn new process
 		process_opts := processOptions{}
-		process_opts.Env = map[gen.EnvKey]interface{}{EnvKeyRemoteSpawn: request.Options}
+		process_opts.Env = map[gen.EnvKey]interface{}{EnvKeyRemoteSpawn: request.Options, "ergo:RemoteSpawnRequest": request}
 		process, err_spawn := c.spawn(request.Options.Name, process_opts, b.Behavior, args...)
 
 		// reply

--- a/proto/dist/proto.go
+++ b/proto/dist/proto.go
@@ -1297,12 +1297,11 @@ func (dc *distConnection) handleMessage(message *distMessage) (err error) {
 				registerName := ""
 				for _, option := range t.Element(6).(etf.List) {
 					name, ok := option.(etf.Tuple)
-					if !ok || len(name) != 2 {
-						return fmt.Errorf("malformed spawn request")
-					}
-					switch name.Element(1) {
-					case etf.Atom("name"):
-						registerName = string(name.Element(2).(etf.Atom))
+					if ok || len(name) == 2 {
+						switch name.Element(1) {
+						case etf.Atom("name"):
+							registerName = string(name.Element(2).(etf.Atom))
+						}
 					}
 				}
 
@@ -1320,6 +1319,14 @@ func (dc *distConnection) handleMessage(message *distMessage) (err error) {
 					// args can't be anything but etf.List.
 					for i := range []byte(str) {
 						args = append(args, str[i])
+					}
+				}
+
+				if registerName == "" {
+					if module == etf.Atom("erpc") {
+						registerName = "erpc"
+					} else {
+						return fmt.Errorf("malformed spawn request")
 					}
 				}
 


### PR DESCRIPTION
`erpc:call/4`,`erpc:cast/4`,`rpc:call/4` are not working properly

**Here is the test code**：
```go
package main

import (
	"flag"
	"fmt"

	"github.com/ergo-services/ergo"
	"github.com/ergo-services/ergo/etf"
	"github.com/ergo-services/ergo/node"
)

var (
	ServerName string
	NodeName   string
	Cookie     string
)

func init() {
	flag.StringVar(&ServerName, "server", "example", "server process name")
	flag.StringVar(&NodeName, "name", "go_node1@127.0.0.1", "node name")
	flag.StringVar(&Cookie, "cookie", "go_erlang_cookie", "cookie for interaction with erlang cluster")
}

func main() {
	flag.Parse()

	fmt.Println("")
	fmt.Println("to stop press Ctrl-C")
	fmt.Println("")

	node, err := ergo.StartNode(NodeName, Cookie, node.Options{})
	if err != nil {
		panic(err)
	}

	testFun1 := func(a ...etf.Term) etf.Term {
		fmt.Printf("go handle --->>> %#v\n", a)
		return a[len(a)-1]
	}
	if e := node.ProvideRPC("testMod", "testFun", testFun1); e != nil {
		panic(err)
	}

	fmt.Println("Start erlang node with the command below:")
	fmt.Printf("    $ erl -name %s -setcookie %s\n\n", "erl-"+node.Name(), Cookie)

	node.Wait()
}
```
**Before fixing the bug**

```bash
#Erlang input 
(erl-go_node1@127.0.0.1)1>  erpc:call('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).  （Blocking）
#Log output of Go
2022/12/07 21:52:55 WARNING! [go_node1@127.0.0.1] Malformed Control packet at the link with erl-go_node1@127.0.0.1: etf.Tuple{29, etf.Ref{Node:"erl-go_node1@127.0.0.1", Creation:0x638455e0, ID:[5]uint32{0x28929, 0x880c0002, 0x30bb6300, 0x0, 0x0}}, etf.Pid{Node:"erl-go_node1@127.0.0.1", ID:0x56, Creation:0x638455e0}, etf.Pid{Node:"erl-go_node1@127.0.0.1", ID:0x48, Creation:0x638455e0}, etf.Tuple{"erpc", "execute_call", 4}, etf.List{"monitor"}}

#Erlang input:
(erl-go_node1@127.0.0.1)1>  rpc:call('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).  （Blocking）
#Log output of Go
2022/12/07 21:52:55 WARNING! [go_node1@127.0.0.1] Malformed Control packet at the link with erl-go_node1@127.0.0.1: etf.Tuple{29, etf.Ref{Node:"erl-go_node1@127.0.0.1", Creation:0x638455e0, ID:[5]uint32{0x28929, 0x880c0002, 0x30bb6300, 0x0, 0x0}}, etf.Pid{Node:"erl-go_node1@127.0.0.1", ID:0x56, Creation:0x638455e0}, etf.Pid{Node:"erl-go_node1@127.0.0.1", ID:0x48, Creation:0x638455e0}, etf.Tuple{"erpc", "execute_call", 4}, etf.List{"monitor"}}


#Erlang input and output:
(erl-go_node1@127.0.0.1)2> erpc:cast('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).
ok
#Log output of Go
2022/12/07 21:55:58 WARNING! initialization process failed <3FA645AA.0.1012>[""] &runtime.TypeAssertionError{_interface:(*runtime._type)(0x6df520), concrete:(*runtime._type)(0x6cd940), asserted:(*runtime._type)(0x700400), missingMethod:""} at runtime.panicdottypeE[/usr/local/go/src/runtime/iface.go:262]
```
**After fixing the bug**

```bash
#Erlang input and output:
$ erl -name erl-go_node1@127.0.0.1 -setcookie go_erlang_cookie
Erlang/OTP 24 [erts-12.1.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]
Eshell V12.1.5  (abort with ^G)
(erl-go_node1@127.0.0.1)1>  erpc:call('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).
111
(erl-go_node1@127.0.0.1)2> rpc:call('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).  
111
(erl-go_node1@127.0.0.1)3> erpc:cast('go_node1@127.0.0.1', testMod, testFun, [a,"hello",111]).
ok

#Log output of Go
go handle --->>> []etf.Term{"a", "hello", 111}
go handle --->>> []etf.Term{"a", "hello", 111}
go handle --->>> []etf.Term{"a", "hello", 111}
```