### PR TITLE
ServerProcess.CastRPC to Erlang Node does not work

### DIFF
--- a/gen/server.go
+++ b/gen/server.go
@@ -151,7 +151,7 @@ func (sp *ServerProcess) CallRPCWithTimeout(timeout int, node, module, function 
 		etf.Atom(module),
 		etf.Atom(function),
 		etf.List(args),
-		sp.Self(),
+		etf.Atom("user"),
 	}
 	to := ProcessID{"rex", node}
 	return sp.CallWithTimeout(to, message, timeout)
@@ -165,7 +165,7 @@ func (sp *ServerProcess) CastRPC(node, module, function string, args ...etf.Term
 		etf.Atom(module),
 		etf.Atom(function),
 		etf.List(args),
-		sp.Self(),
+		etf.Atom("user"),
 	}
 	to := ProcessID{"rex", node}
 	return sp.Cast(to, message)

--- a/gen/server.go
+++ b/gen/server.go
@@ -165,6 +165,7 @@ func (sp *ServerProcess) CastRPC(node, module, function string, args ...etf.Term
 		etf.Atom(module),
 		etf.Atom(function),
 		etf.List(args),
+		sp.Self(),
 	}
 	to := ProcessID{"rex", node}
 	return sp.Cast(to, message)


### PR DESCRIPTION
**Here is the test code**：

```go
package main

import (
	"fmt"
	"time"

	"github.com/ergo-services/ergo"
	"github.com/ergo-services/ergo/etf"
	"github.com/ergo-services/ergo/gen"
	"github.com/ergo-services/ergo/node"
)

var demoSP *gen.ServerProcess

type demo struct {
	gen.Server
}

func (d *demo) Init(process *gen.ServerProcess, args ...etf.Term) error {
	demoSP = process
	return nil
}

func main() {
	NodeName := "go_node3@127.0.0.1"
	Cookie := "cookie"

	node, err := ergo.StartNode(NodeName, Cookie, node.Options{})
	if err != nil {
		panic(err)
	}
	_, err = node.Spawn("demo_server", gen.ProcessOptions{}, &demo{})
	if err != nil {
		panic(err)
	}
	remoteNode := "erl-" + node.Name()
	fmt.Println("Start erlang node with the command below:")
	fmt.Printf("    $ erl -name %s -setcookie %s\n\n", remoteNode, Cookie)
	if v, e := demoSP.CallRPC(remoteNode, "persistent_term", "get", etf.Atom("test_key"), etf.Atom("default")); e == nil {
		fmt.Printf("rpc:call erl_node = %+v\n", v)
	} else {
		fmt.Printf("rpc:call erl_node err = %+v\n", e)
	}

	if e := demoSP.CastRPC(remoteNode, "persistent_term", "put", etf.Atom("test_key"), etf.Atom("cast_rpc")); e == nil {
		fmt.Printf("rpc:cast erl_node = %+v\n", "ok")
	} else {
		fmt.Printf("rpc:cast erl_node err = %+v\n", e)
	}
	time.Sleep(time.Second)

	if v, e := demoSP.CallRPC(remoteNode, "persistent_term", "get", etf.Atom("test_key"), etf.Atom("default")); e == nil {
		fmt.Printf("rpc:call erl_node = %+v\n", v)
	} else {
		fmt.Printf("rpc:call erl_node err = %+v\n", e)
	}

	node.Wait()
}
```
**Open Erlang node**:

```
 erl -name erl-go_node3@127.0.0.1 -setcookie cookie
```

**Before fix**:

```bash
#output:
rpc:call erl_node = default
rpc:cast erl_node = ok
rpc:call erl_node = default
```
**After fix**:

```bash
#output:
rpc:call erl_node = default
rpc:cast erl_node = ok
rpc:call erl_node = cast_rpc
```