### PR TITLE
migrate ServerProcess.CastAfter/Cast/CastRPC to process  for true gen_cast/2

### DIFF
--- a/gen/server.go
+++ b/gen/server.go
@@ -3,7 +3,6 @@ package gen
 import (
 	"fmt"
 	"runtime"
-	"time"
 
 	"github.com/ergo-services/ergo/etf"
 	"github.com/ergo-services/ergo/lib"
@@ -101,19 +100,6 @@ type handleInfoMessage struct {
 	message etf.Term
 }
 
-// CastAfter a simple wrapper for Process.SendAfter to send a message in fashion of 'gen_server:cast'
-func (sp *ServerProcess) CastAfter(to interface{}, message etf.Term, after time.Duration) CancelFunc {
-	msg := etf.Term(etf.Tuple{etf.Atom("$gen_cast"), message})
-	return sp.SendAfter(to, msg, after)
-}
-
-// Cast sends a message in fashion of 'gen_server:cast'. 'to' can be a Pid, registered local name
-// or gen.ProcessID{RegisteredName, NodeName}
-func (sp *ServerProcess) Cast(to interface{}, message etf.Term) error {
-	msg := etf.Term(etf.Tuple{etf.Atom("$gen_cast"), message})
-	return sp.Send(to, msg)
-}
-
 // Call makes outgoing sync request in fashion of 'gen_server:call'.
 // 'to' can be Pid, registered local name or gen.ProcessID{RegisteredName, NodeName}.
 func (sp *ServerProcess) Call(to interface{}, message etf.Term) (etf.Term, error) {
@@ -155,19 +141,6 @@ func (sp *ServerProcess) CallRPCWithTimeout(timeout int, node, module, function 
 	}
 	to := ProcessID{"rex", node}
 	return sp.CallWithTimeout(to, message, timeout)
-}
-
-// CastRPC evaluate rpc cast with given node/MFA
-func (sp *ServerProcess) CastRPC(node, module, function string, args ...etf.Term) error {
-	lib.Log("[%s] RPC casting: %s:%s:%s", sp.NodeName(), node, module, function)
-	message := etf.Tuple{
-		etf.Atom("cast"),
-		etf.Atom(module),
-		etf.Atom(function),
-		etf.List(args),
-	}
-	to := ProcessID{"rex", node}
-	return sp.Cast(to, message)
 }
 
 // SendReply sends a reply message to the sender made ServerProcess.Call request.

--- a/gen/types.go
+++ b/gen/types.go
@@ -55,6 +55,16 @@ type Process interface {
 	// DirectWithTimeout make a direct request to the actor with the given timeout (in seconds)
 	DirectWithTimeout(request interface{}, timeout int) (interface{}, error)
 
+	// Cast sends a message in fashion of 'gen_server:cast'. 'to' can be a Pid, registered local name
+	// or gen.ProcessID{RegisteredName, NodeName}
+	Cast(to interface{}, message etf.Term) error
+
+	// CastAfter a simple wrapper for Process.SendAfter to send a message in fashion of 'gen_server:cast'
+	CastAfter(to interface{}, message etf.Term, after time.Duration) CancelFunc
+
+	// CastRPC evaluate rpc cast with given node/MFA
+	CastRPC(node, module, function string, args ...etf.Term) error
+
 	// Send sends a message in fashion of 'erlang:send'. The value of 'to' can be a Pid, registered local name
 	// or gen.ProcessID{RegisteredName, NodeName}
 	Send(to interface{}, message etf.Term) error
@@ -357,10 +367,10 @@ func (p ProcessID) String() string {
 // MessageDown delivers as a message to Server's HandleInfo callback of the process
 // that created monitor using MonitorProcess.
 // Reason values:
-//  - the exit reason of the process
-//  - 'noproc' (process did not exist at the time of monitor creation)
-//  - 'noconnection' (no connection to the node where the monitored process resides)
-//  - 'noproxy' (no connection to the proxy this node had has a connection through. monitored process could be still alive)
+//   - the exit reason of the process
+//   - 'noproc' (process did not exist at the time of monitor creation)
+//   - 'noconnection' (no connection to the node where the monitored process resides)
+//   - 'noproxy' (no connection to the proxy this node had has a connection through. monitored process could be still alive)
 type MessageDown struct {
 	Ref       etf.Ref   // a monitor reference
 	ProcessID ProcessID // if monitor was created by name
@@ -387,10 +397,10 @@ type MessageProxyDown struct {
 
 // MessageExit delievers to Server's HandleInfo callback on enabled trap exit using SetTrapExit(true)
 // Reason values:
-//  - the exit reason of the process
-//  - 'noproc' (process did not exist at the time of link creation)
-//  - 'noconnection' (no connection to the node where the linked process resides)
-//  - 'noproxy' (no connection to the proxy this node had has a connection through. linked process could be still alive)
+//   - the exit reason of the process
+//   - 'noproc' (process did not exist at the time of link creation)
+//   - 'noconnection' (no connection to the node where the linked process resides)
+//   - 'noproxy' (no connection to the proxy this node had has a connection through. linked process could be still alive)
 type MessageExit struct {
 	Pid    etf.Pid
 	Reason string

--- a/node/process.go
+++ b/node/process.go
@@ -214,6 +214,31 @@ func (p *process) Send(to interface{}, message etf.Term) error {
 	return fmt.Errorf("Unknown receiver type")
 }
 
+// CastAfter
+func (p *process) CastAfter(to interface{}, message etf.Term, after time.Duration) gen.CancelFunc {
+	msg := etf.Term(etf.Tuple{etf.Atom("$gen_cast"), message})
+	return p.SendAfter(to, msg, after)
+}
+
+// Cast
+func (p *process) Cast(to interface{}, message etf.Term) error {
+	msg := etf.Term(etf.Tuple{etf.Atom("$gen_cast"), message})
+	return p.Send(to, msg)
+}
+
+// CastRPC
+func (p *process) CastRPC(node, module, function string, args ...etf.Term) error {
+	lib.Log("[%s] RPC casting: %s:%s:%s", p.NodeName(), node, module, function)
+	message := etf.Tuple{
+		etf.Atom("cast"),
+		etf.Atom(module),
+		etf.Atom(function),
+		etf.List(args),
+	}
+	to := gen.ProcessID{Name: "rex", Node: node}
+	return p.Cast(to, message)
+}
+
 // SendAfter
 func (p *process) SendAfter(to interface{}, message etf.Term, after time.Duration) gen.CancelFunc {
 


### PR DESCRIPTION
`gen.ServerProcess `inherits `gen.Process,` so it is backwards compatible.

This makes it possible to send Cast messages to other ServerProcesses in Ergo in any Goroutine without restriction, just like `gen_server:cast/2` in Erlang. Improved ease of use of the framework.