### PR TITLE
go run -race Warning data race

### DIFF
--- a/gen/application.go
+++ b/gen/application.go
@@ -115,7 +115,11 @@ func (a *Application) ProcessInit(p Process, args ...etf.Term) (ProcessState, er
 // ProcessLoop
 func (a *Application) ProcessLoop(ps ProcessState, started chan<- bool) string {
 	spec := ps.State.(*ApplicationSpec)
-	defer func() { spec.Process = nil }()
+	defer func() {
+		spec.Mutex.Lock()
+		spec.Process = nil
+		spec.Mutex.Unlock()
+	}()
 
 	if spec.Lifespan == 0 {
 		spec.Lifespan = time.Hour * 24 * 365 * 100 // let's define default lifespan 100 years :)

--- a/node/node.go
+++ b/node/node.go
@@ -196,7 +196,9 @@ func (n *node) listApplications(onlyRunning bool) []gen.ApplicationInfo {
 			continue
 		}
 
+		spec.Mutex.Lock()
 		if onlyRunning && spec.Process == nil {
+			spec.Mutex.Unlock()
 			// list only started apps
 			continue
 		}
@@ -209,6 +211,8 @@ func (n *node) listApplications(onlyRunning bool) []gen.ApplicationInfo {
 		if spec.Process != nil {
 			appInfo.PID = spec.Process.Self()
 		}
+		spec.Mutex.Unlock()
+
 		info = append(info, appInfo)
 	}
 	return info


### PR DESCRIPTION
WARNING: DATA RACE
Write at 0x00c0005c41b8 by goroutine 152:
  github.com/ergo-services/ergo/gen.(*Application).ProcessLoop.func1()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/gen/application.go:118 +0x39
  runtime.deferreturn()
      E:/Golang/src/runtime/panic.go:476 +0x32
  myApp/myApp.(*MyApp).ProcessLoop()
      <autogenerated>:1 +0x95
  github.com/ergo-services/ergo/node.(*core).spawn.func3()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/node/core.go:521 +0x19e
  github.com/ergo-services/ergo/node.(*core).spawn.func5()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/node/core.go:525 +0x74

Previous read at 0x00c0005c41b8 by goroutine 179:
  github.com/ergo-services/ergo/node.(*node).listApplications()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/node/node.go:199 +0x153
  github.com/ergo-services/ergo/node.(*node).WhichApplications()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/node/node.go:187 +0x176
  github.com/ergo-services/ergo/node.(*node).Stats()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/node/node.go:165 +0x177
  github.com/ergo-services/ergo/apps/system.gatherStats()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/apps/system/metrics.go:175 +0x19d
  github.com/ergo-services/ergo/apps/system.(*systemMetrics).HandleCast()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/apps/system/metrics.go:75 +0x2f5
  github.com/ergo-services/ergo/gen.(*ServerProcess).handleCast()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/gen/server.go:518 +0x16d
  github.com/ergo-services/ergo/gen.(*ServerProcess).waitCallbackOrDeferr.func2()
      E:/goEnv/go/pkg/mod/github.com/ergo-services/ergo@v1.999.224/gen/server.go:424 +0x8c
