### PR TITLE
chore(node): ensure route host is set if empty during connection

### DIFF
--- a/node/network.go
+++ b/node/network.go
@@ -700,6 +700,10 @@ func (n *network) connect(name gen.Atom, route gen.NetworkRoute) (gen.Connection
 	handshake := vhandshake.(gen.NetworkHandshake)
 	proto := vproto.(gen.NetworkProto)
 
+	if route.Route.Host == "" {
+		route.Route.Host = name.Host()
+	}
+
 	if lib.Trace() {
 		n.node.Log().Trace("trying to connect to %s (%s:%d, tls:%v)",
 			name, route.Route.Host, route.Route.Port, route.Route.TLS)


### PR DESCRIPTION
This change ensures that the route host is set to the name's host if it is empty, preventing potential connection issues.

Ideally this would be checked and updated much earlier on the stack upon registering.

https://github.com/nanovms/nanos/issues/2069#issue-2547740041 is an example of an environment that does not allow the actual behavior (since connecting to 0.0.0.0 or [::] is non-standard practice)