### PR TITLE
 Fix incorrect "abnormal termination" logging during planned shutdown

### DIFF
--- a/meta/tcp_server.go
+++ b/meta/tcp_server.go
@@ -118,7 +118,7 @@ func (t *tcpserver) HandleCall(from gen.PID, ref gen.Ref, request any) (any, err
 func (t *tcpserver) Terminate(reason error) {
 	defer t.listener.Close()
 
-	if reason == nil || reason == gen.TerminateReasonNormal {
+	if reason == nil || reason == gen.TerminateReasonNormal || reason == gen.TerminateReasonShutdown {
 		return
 	}
 	t.Log().Error("terminated abnormaly: %s", reason)


### PR DESCRIPTION
**Description:**
This PR modifies the termination logic in tcpserver.Terminate() to avoid logging false-positive error messages when the service is intentionally shut down.

**Changes:**

- Added gen.TerminateReasonShutdown to the allowed termination reasons in tcpserver.Terminate()
- Updated conditional check to skip error logging for both normal exits and planned shutdowns
- Preserved error logging for truly unexpected termination reasons

**Error Message Fix:**
Previously, a planned shutdown would generate a misleading error log:
`2025-03-08 17:12:53 [error] Alias#<10E422CB.60135.24747.0>: terminated abnormaly: shutdown`