### PR TITLE
Initial StateMachine implementation

### DIFF
--- a/act/statemachine.go
+++ b/act/statemachine.go
@@ -1,0 +1,317 @@
+package act
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+
+	"ergo.services/ergo/gen"
+	"ergo.services/ergo/lib"
+)
+
+type StateMachineBehavior[D any] interface {
+	gen.ProcessBehavior
+
+	Init(args ...any) (StateMachineSpec[D], error)
+
+	HandleMessage(from gen.PID, message any) error
+
+	HandleCall(from gen.PID, ref gen.Ref, message any) (any, error)
+
+	HandleEvent(event gen.MessageEvent) error
+
+	HandleInspect(from gen.PID, item ...string) map[string]string
+
+	Terminate(reason error)
+
+	CurrentState() gen.Atom
+
+	SetCurrentState(gen.Atom)
+
+	Data() D
+
+	SetData(data D)
+}
+
+type StateMachine[D any] struct {
+	gen.Process
+
+	behavior StateMachineBehavior[D]
+	mailbox  gen.ProcessMailbox
+
+	spec StateMachineSpec[D]
+
+	currentState   gen.Atom
+	data           D
+	stateCallbacks map[gen.Atom]map[string]interface{}
+}
+
+type StateCallback[D any, M any] func(*StateMachine[D], M) error
+
+type StateMachineSpec[D any] struct {
+	initialState   gen.Atom
+	stateCallbacks map[gen.Atom]map[string]interface{}
+}
+
+type AddCallback[D any] func(*StateMachineSpec[D])
+
+func NewStateMachineSpec[D any](initialState gen.Atom, callbacks ...AddCallback[D]) StateMachineSpec[D] {
+	spec := StateMachineSpec[D]{
+		initialState:   initialState,
+		stateCallbacks: make(map[gen.Atom]map[string]interface{}),
+	}
+	for _, cb := range callbacks {
+		cb(&spec)
+	}
+	return spec
+}
+
+func WithStateCallback[D any, M any](state gen.Atom, callback func(*StateMachine[D], M) error) AddCallback[D] {
+	typeName := reflect.TypeOf((*M)(nil)).Elem().String()
+	return func(s *StateMachineSpec[D]) {
+		if _, exists := s.stateCallbacks[state]; exists == false {
+			s.stateCallbacks[state] = make(map[string]interface{})
+		}
+		s.stateCallbacks[state][typeName] = callback
+	}
+}
+
+func (s *StateMachine[D]) CurrentState() gen.Atom {
+	return s.currentState
+}
+
+func (s *StateMachine[D]) SetCurrentState(state gen.Atom) {
+	s.currentState = state
+}
+
+func (s *StateMachine[D]) Data() D {
+	return s.data
+}
+
+func (s *StateMachine[D]) SetData(data D) {
+	s.data = data
+}
+
+//
+// ProcessBehavior implementation
+//
+
+func (sm *StateMachine[D]) ProcessInit(process gen.Process, args ...any) (rr error) {
+	var ok bool
+
+	if sm.behavior, ok = process.Behavior().(StateMachineBehavior[D]); ok == false {
+		unknown := strings.TrimPrefix(reflect.TypeOf(process.Behavior()).String(), "*")
+		return fmt.Errorf("ProcessInit: not a StateMachineBehavior %s", unknown)
+	}
+
+	sm.Process = process
+	sm.mailbox = process.Mailbox()
+
+	if lib.Recover() {
+		defer func() {
+			if r := recover(); r != nil {
+				pc, fn, line, _ := runtime.Caller(2)
+				sm.Log().Panic("StateMachine initialization failed. Panic reason: %#v at %s[%s:%d]",
+					r, runtime.FuncForPC(pc).Name(), fn, line)
+				rr = gen.TerminateReasonPanic
+			}
+		}()
+	}
+
+	spec, err := sm.behavior.Init(args...)
+	if err != nil {
+		return err
+	}
+
+	// set up callbacks
+	sm.currentState = spec.initialState
+	sm.stateCallbacks = spec.stateCallbacks
+
+	return nil
+}
+
+func (sm *StateMachine[D]) ProcessRun() (rr error) {
+	var message *gen.MailboxMessage
+
+	if lib.Recover() {
+		defer func() {
+			if r := recover(); r != nil {
+				pc, fn, line, _ := runtime.Caller(2)
+				sm.Log().Panic("StateMachine terminated. Panic reason: %#v at %s[%s:%d]",
+					r, runtime.FuncForPC(pc).Name(), fn, line)
+				rr = gen.TerminateReasonPanic
+			}
+		}()
+	}
+
+	for {
+		if sm.State() != gen.ProcessStateRunning {
+			// process was killed by the node.
+			return gen.TerminateReasonKill
+		}
+
+		if message != nil {
+			gen.ReleaseMailboxMessage(message)
+			message = nil
+		}
+
+		for {
+			// check queues
+			msg, ok := sm.mailbox.Urgent.Pop()
+			if ok {
+				// got new urgent message. handle it
+				message = msg.(*gen.MailboxMessage)
+				break
+			}
+
+			msg, ok = sm.mailbox.System.Pop()
+			if ok {
+				// got new system message. handle it
+				message = msg.(*gen.MailboxMessage)
+				break
+			}
+
+			msg, ok = sm.mailbox.Main.Pop()
+			if ok {
+				// got new regular message. handle it
+				message = msg.(*gen.MailboxMessage)
+				break
+			}
+
+			if _, ok := sm.mailbox.Log.Pop(); ok {
+				panic("statemachne process can not be a logger")
+			}
+
+			// no messages in the mailbox
+			return nil
+		}
+
+		switch message.Type {
+		case gen.MailboxMessageTypeRegular:
+			// check if there is a handler for the message in the current state
+			typeName := typeName(message)
+			if callbackInterface, ok := sm.lookupCallback(typeName); ok == true {
+				callbackValue := reflect.ValueOf(callbackInterface)
+				smValue := reflect.ValueOf(sm)
+				msgValue := reflect.ValueOf(message.Message)
+
+				results := callbackValue.Call([]reflect.Value{smValue, msgValue})
+
+				if len(results) > 0 && !results[0].IsNil() {
+					return results[0].Interface().(error)
+				}
+				return nil
+			}
+			return fmt.Errorf("Unsupported message %s for state %s", typeName, sm.currentState)
+
+		case gen.MailboxMessageTypeRequest:
+			var reason error
+			var result gen.Atom = sm.CurrentState()
+
+			// check if there is a handler for the call in the current state
+			typeName := typeName(message)
+			if callbackInterface, ok := sm.lookupCallback(typeName); ok == true {
+				callbackValue := reflect.ValueOf(callbackInterface)
+				smValue := reflect.ValueOf(sm)
+				msgValue := reflect.ValueOf(message.Message)
+
+				results := callbackValue.Call([]reflect.Value{smValue, msgValue})
+
+				if len(results) > 0 && !results[0].IsNil() {
+					reason = results[0].Interface().(error)
+				}
+				result = sm.CurrentState()
+			} else {
+				reason = fmt.Errorf("Unsupported call %s for state %s", typeName, sm.currentState)
+			}
+
+			if reason != nil {
+				// if reason is "normal" and we got response - send it before termination
+				if reason == gen.TerminateReasonNormal {
+					sm.SendResponse(message.From, message.Ref, result)
+				}
+				return reason
+			}
+
+			// Note: we do not support async handling of sync request at the moment
+
+			sm.SendResponse(message.From, message.Ref, result)
+
+		case gen.MailboxMessageTypeEvent:
+			if reason := sm.behavior.HandleEvent(message.Message.(gen.MessageEvent)); reason != nil {
+				return reason
+			}
+
+		case gen.MailboxMessageTypeExit:
+			switch exit := message.Message.(type) {
+			case gen.MessageExitPID:
+				return fmt.Errorf("%s: %w", exit.PID, exit.Reason)
+
+			case gen.MessageExitProcessID:
+				return fmt.Errorf("%s: %w", exit.ProcessID, exit.Reason)
+
+			case gen.MessageExitAlias:
+				return fmt.Errorf("%s: %w", exit.Alias, exit.Reason)
+
+			case gen.MessageExitEvent:
+				return fmt.Errorf("%s: %w", exit.Event, exit.Reason)
+
+			case gen.MessageExitNode:
+				return fmt.Errorf("%s: %w", exit.Name, gen.ErrNoConnection)
+
+			default:
+				panic(fmt.Sprintf("unknown exit message: %#v", exit))
+			}
+
+		case gen.MailboxMessageTypeInspect:
+			result := sm.behavior.HandleInspect(message.From, message.Message.([]string)...)
+			sm.SendResponse(message.From, message.Ref, result)
+		}
+	}
+}
+
+func (sm *StateMachine[D]) ProcessTerminate(reason error) {
+	sm.behavior.Terminate(reason)
+}
+
+//
+// StateMachineBehavior default callbacks
+//
+
+func (s *StateMachine[D]) HandleMessage(from gen.PID, message any) error {
+	s.Log().Warning("StateMachine.HandleMessage: unhandled message from %s", from)
+	return nil
+}
+
+func (s *StateMachine[D]) HandleCall(from gen.PID, ref gen.Ref, request any) (any, error) {
+	s.Log().Warning("StateMachine.HandleCall: unhandled request from %s", from)
+	return nil, nil
+}
+func (s *StateMachine[D]) HandleEvent(message gen.MessageEvent) error {
+	s.Log().Warning("StateMachine.HandleEvent: unhandled event message %#v", message)
+	return nil
+}
+
+func (s *StateMachine[D]) HandleInspect(from gen.PID, item ...string) map[string]string {
+	return nil
+}
+
+func (s *StateMachine[D]) Terminate(reason error) {}
+
+//
+// Internals
+//
+
+func typeName(message *gen.MailboxMessage) string {
+	return reflect.TypeOf(message.Message).String()
+}
+
+func (sm *StateMachine[D]) lookupCallback(messageType string) (interface{}, bool) {
+	if stateCallbacks, exists := sm.stateCallbacks[sm.currentState]; exists == true {
+		if callback, exists := stateCallbacks[messageType]; exists == true {
+			return callback, true
+		}
+	}
+	return nil, false
+}

--- a/tests/001_local/t018_statemachine_test.go
+++ b/tests/001_local/t018_statemachine_test.go
@@ -1,0 +1,155 @@
+package local
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"ergo.services/ergo"
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+)
+
+//
+// this is the template for writing new tests
+//
+
+var (
+	t18cases []*testcase
+)
+
+func factory_t18() gen.ProcessBehavior {
+	return &t18{}
+}
+
+type t18 struct {
+	act.Actor
+
+	testcase *testcase
+}
+
+func (t *t18) HandleMessage(from gen.PID, message any) error {
+	if t.testcase == nil {
+		t.testcase = message.(*testcase)
+		message = initcase{}
+	}
+	// get method by name
+	method := reflect.ValueOf(t).MethodByName(t.testcase.name)
+	if method.IsValid() == false {
+		t.testcase.err <- fmt.Errorf("unknown method %q", t.testcase.name)
+		t.testcase = nil
+		return nil
+	}
+	method.Call([]reflect.Value{reflect.ValueOf(message)})
+	return nil
+}
+
+func factory_t18statemachine() gen.ProcessBehavior {
+	return &t18statemachine{}
+}
+
+type t18statemachine struct {
+	act.StateMachine[t18data]
+	tc *testcase
+}
+
+type t18data struct {
+	count int
+}
+
+type t18transition1 struct {
+}
+
+type t18transition2 struct {
+}
+
+func (sm *t18statemachine) Init(args ...any) (act.StateMachineSpec[t18data], error) {
+	spec := act.NewStateMachineSpec(gen.Atom("state1"),
+		act.WithStateCallback(gen.Atom("state1"), state1to2),
+		act.WithStateCallback(gen.Atom("state2"), state2to1),
+	)
+
+	return spec, nil
+}
+
+func state1to2(sm *act.StateMachine[t18data], message t18transition1) error {
+	sm.SetCurrentState(gen.Atom("state2"))
+	data := sm.Data()
+	data.count++
+	sm.SetData(data)
+	return nil
+}
+
+func state2to1(sm *act.StateMachine[t18data], message t18transition2) error {
+	sm.SetCurrentState(gen.Atom("state1"))
+	data := sm.Data()
+	data.count++
+	sm.SetData(data)
+	return nil
+}
+
+func (t *t18) TestStateMachine(input any) {
+	defer func() {
+		t.testcase = nil
+	}()
+
+	pid, err := t.Spawn(factory_t18statemachine, gen.ProcessOptions{})
+	if err != nil {
+		t.Log().Error("unable to spawn statemachine process: %s", err)
+		t.testcase.err <- err
+		return
+	}
+
+	// send message to transition from state 1 to 2
+	err = t.Send(pid, t18transition1{})
+
+	if err != nil {
+		t.Log().Error("sending to the statemachine process failed: %s", err)
+		t.testcase.err <- err
+		return
+	}
+
+	// send call to transition from state 2 to 1
+	state, err := t.Call(pid, t18transition2{})
+	if err != nil {
+		t.Log().Error("call to the statemachine process failed: %s", err)
+		t.testcase.err <- err
+		return
+	}
+	if state != gen.Atom("state1") {
+		t.testcase.err <- fmt.Errorf("expected state1, got %v", state)
+		return
+	}
+
+	t.testcase.err <- nil
+}
+
+func TestTt18template(t *testing.T) {
+	nopt := gen.NodeOptions{}
+	//nopt.Log.DefaultLogger.Disable = true
+	//nopt.Log.Level = gen.LogLevelTrace
+	node, err := ergo.StartNode("t18node@localhost", nopt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	popt := gen.ProcessOptions{}
+	pid, err := node.Spawn(factory_t18, popt)
+	if err != nil {
+		panic(err)
+	}
+
+	t18cases = []*testcase{
+		&testcase{"TestStateMachine", nil, nil, make(chan error)},
+	}
+	for _, tc := range t18cases {
+		t.Run(tc.name, func(t *testing.T) {
+			node.Send(pid, tc)
+			if err := tc.wait(3); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	node.Stop()
+}


### PR DESCRIPTION
## RFC: Add a state machine implementation

### Background
This draft PR proposes a `StateMachine` to be added to the standard actors library. The implementation is loosely based on [gen_statem](https://www.erlang.org/doc/system/statem.html). It operates similarly to `gen_statem` in callback mode `state_functions`, but instead of a single callback per state we use a callback per `(state, messageType)` tuple. 

### Implementation
The `StateMachine` is implemented as an Actor in the standard actors library. It follows the same pattern as the `Supervisor` where the `Init` function implementation is mandatory and returns the specification of the `StateMachine`. The specification in this draft PR contains the initial state as well as the callback functions for the states. States are of type `gen.Atom`, similar to their Erlang/Elixir counterparts, and the `StateMachine` has a generic type parameter `D` for the data associated with the state machine (again akin to the Erlang implementation). A difference with the Erlang implementation is that the data and the new state are not returned from the state callback functions, instead they are part of the mutable state of the actor.

For creating the `StateMachineSpec` there are several helper functions and types as we need to capture the type of the message being processed by the callbacks. We also want to reduce unnecessary copying of the spec, therefore we use the [functional option pattern](https://golang.cafe/blog/golang-functional-options-pattern.html). To demonstrate what this API "feels like" I created a PR in the examples repo.

When attempting an invalid state transition, following Erlang/OTP's "let it crash" philosophy, the process terminates.

### Open questions
- Does this API make sense? Should we have mutable state and allow this state to be mutated in the state callbacks, or should we have a more functional API where the callbacks return the next state and the updated data?
- What should we do with events? Does it make sense to have events tied to states, should events be delivered to all states or should we make this configurable per event (which I believe the Erlang implementation does).
- The Erlang implementation has support for event postponing, in case an event is not applicable to the state at the time of the initial delivery. Their implementation redelivers the event when the state has changed.

### TODO (not necessarily in an initial implementation)
- [ ] have a means of injecting the initial data
- [ ] support for timeouts (state timeouts, event timeouts, generic timeouts)
- [ ] support for events
- [ ] state enter callbacks (for code you want to run on _every_ state transition)
