### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/001_local/common.go
+++ b/tests/001_local/common.go
@@ -30,3 +30,22 @@ func (t *testcase) wait(timeout int) error {
 		return e
 	}
 }
+
+func (t *testcase) waitForCondition(timeout time.Duration, condition func() bool) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if condition() {
+				return
+			}
+		case <-timer.C:
+			t.err <- fmt.Errorf("timeout waiting for condition after %s", timeout)
+			return
+		}
+	}
+}

--- a/tests/001_local/t004_actor_call_test.go
+++ b/tests/001_local/t004_actor_call_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"ergo.services/ergo"
 	"ergo.services/ergo/act"
@@ -94,10 +95,10 @@ func (t *t4) TestCallPID(input any) {
 	}
 
 	// must be stopped here
-	if _, err := t.Node().ProcessInfo(pid); err != gen.ErrProcessUnknown {
-		t.testcase.err <- errIncorrect
-		return
-	}
+	t.testcase.waitForCondition(1*time.Second, func() bool {
+		_, err := t.Node().ProcessInfo(pid)
+		return err == gen.ErrProcessUnknown
+	})
 
 	t.testcase.err <- nil
 }
@@ -136,10 +137,10 @@ func (t *t4) TestCallProcessID(input any) {
 	}
 
 	// must be stopped here
-	if _, err := t.Node().ProcessInfo(pid); err != gen.ErrProcessUnknown {
-		t.testcase.err <- errIncorrect
-		return
-	}
+	t.testcase.waitForCondition(1*time.Second, func() bool {
+		_, err := t.Node().ProcessInfo(pid)
+		return err == gen.ErrProcessUnknown
+	})
 
 	t.testcase.err <- nil
 }
@@ -178,10 +179,10 @@ func (t *t4) TestCallAlias(input any) {
 	}
 
 	// must be stopped here
-	if _, err := t.Node().ProcessInfo(pid); err != gen.ErrProcessUnknown {
-		t.testcase.err <- errIncorrect
-		return
-	}
+	t.testcase.waitForCondition(1*time.Second, func() bool {
+		_, err := t.Node().ProcessInfo(pid)
+		return err == gen.ErrProcessUnknown
+	})
 
 	t.testcase.err <- nil
 }
@@ -214,10 +215,10 @@ func (t *t4) TestCallForward(input any) {
 	}
 
 	// must be stopped here
-	if _, err := t.Node().ProcessInfo(pid); err != gen.ErrProcessUnknown {
-		t.testcase.err <- errIncorrect
-		return
-	}
+	t.testcase.waitForCondition(1*time.Second, func() bool {
+		_, err := t.Node().ProcessInfo(pid)
+		return err == gen.ErrProcessUnknown
+	})
 
 	t.testcase.err <- nil
 }

--- a/tests/001_local/t012_application_test.go
+++ b/tests/001_local/t012_application_test.go
@@ -89,10 +89,7 @@ func (tam *testAppMode) Load(node gen.Node, args ...any) (gen.ApplicationSpec, e
 }
 func (tad *testAppMode) Start(mode gen.ApplicationMode) {}
 func (tad *testAppMode) Terminate(reason error) {
-	select {
-	case tad.testcase.err <- reason:
-	default:
-	}
+	tad.testcase.err <- reason
 }
 
 var (


### PR DESCRIPTION
Partially fixes https://github.com/ergo-services/ergo/issues/220

In `t004` the problem was that the process hadn't always stopped at the point of the assertion. I've added a `waitForCondition` helper to do this.

In `t012` the problem was that sometimes the `select` would fall through the default case. I wasn't sure what the intent of the `select` was. Removing it makes the test consistently pass.