### PR TITLE
fix: simultaneous connect dead loop

### DIFF
--- a/net/handshake/join.go
+++ b/net/handshake/join.go
@@ -3,6 +3,7 @@ package handshake
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"net"
 	"time"
 
@@ -52,5 +53,31 @@ func (h *handshake) Join(node gen.NodeHandshake, conn net.Conn, id string, optio
 		}
 	}
 
-	return tail, nil
+	var status byte
+	if len(tail) > 0 {
+		status = tail[0]
+		tail = tail[1:]
+	} else {
+		var b [1]byte
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		if _, err := io.ReadFull(conn, b[:]); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		status = b[0]
+	}
+
+	switch status {
+	case 0:
+		return tail, nil
+	case 1:
+		conn.Close()
+		return nil, fmt.Errorf("join rejected: connection id mismatch")
+	case 2:
+		conn.Close()
+		return nil, fmt.Errorf("join rejected: no existing connection")
+	default:
+		conn.Close()
+		return nil, fmt.Errorf("join rejected")
+	}
 }

--- a/node/network.go
+++ b/node/network.go
@@ -62,6 +62,13 @@ type network struct {
 	enableAppStart sync.Map
 
 	connections sync.Map // gen.Atom (peer name) => gen.Connection
+	connecting  sync.Map // gen.Atom (peer name) => *connectCall
+}
+
+type connectCall struct {
+	done chan struct{}
+	conn gen.Connection
+	err  error
 }
 
 func (n *network) Registrar() (gen.Registrar, error) {
@@ -520,6 +527,29 @@ func (n *network) GetConnection(name gen.Atom) (gen.Connection, error) {
 		return v.(gen.Connection), nil
 	}
 
+	call := &connectCall{done: make(chan struct{})}
+	if actual, loaded := n.connecting.LoadOrStore(name, call); loaded {
+		c := actual.(*connectCall)
+		<-c.done
+		if c.conn != nil {
+			return c.conn, nil
+		}
+		if v, found := n.connections.Load(name); found {
+			return v.(gen.Connection), nil
+		}
+		return nil, c.err
+	}
+
+	conn, err := n.getConnectionSlow(name)
+	call.conn = conn
+	call.err = err
+	close(call.done)
+	n.connecting.Delete(name)
+	return conn, err
+}
+
+func (n *network) getConnectionSlow(name gen.Atom) (gen.Connection, error) {
+
 	if lib.Trace() {
 		n.node.Log().Trace("trying to make connection with %s", name)
 	}
@@ -793,6 +823,11 @@ func (n *network) connect(name gen.Atom, route gen.NetworkRoute) (gen.Connection
 		}
 		tail, err := handshake.Join(n.node, c, id, hopts)
 		if err != nil {
+			c.Close()
+			if strings.Contains(err.Error(), "join rejected: connection id mismatch") ||
+				strings.Contains(err.Error(), "join rejected: no existing connection") {
+				pconn.Terminate(gen.ErrNoConnection)
+			}
 			return nil, nil, err
 		}
 		return c, tail, nil
@@ -800,6 +835,8 @@ func (n *network) connect(name gen.Atom, route gen.NetworkRoute) (gen.Connection
 
 	if c, err := n.registerConnection(result.Peer, pconn); err != nil {
 		if err == gen.ErrTaken {
+			pconn.Terminate(gen.TerminateReasonNormal)
+			conn.Close()
 			return c, nil
 		}
 		pconn.Terminate(err)
@@ -826,8 +863,16 @@ func (n *network) serve(proto gen.NetworkProto, conn gen.Connection, redial gen.
 	}
 
 	err := proto.Serve(conn, redial)
-	n.unregisterConnection(name, err)
+	if v, exist := n.connections.Load(name); exist {
+		if v.(gen.Connection) == conn {
+			n.unregisterConnection(name, err)
+		}
+	}
 	conn.Terminate(err)
+}
+
+func (n *network) preferIncomingOnCollision(peer gen.Atom) bool {
+	return string(n.node.name) > string(peer)
 }
 
 func (n *network) connectProxy(name gen.Atom, route gen.NetworkProxyRoute) (gen.Connection, error) {
@@ -1204,11 +1249,62 @@ func (n *network) accept(a *acceptor) {
 			mapping[k] = v
 		}
 		result.AtomMapping = mapping
+		joinHandshake := result.PeerCreation == 0
 
 		// check if we already have connection with this node
 		if v, exist := n.connections.Load(result.Peer); exist {
 			conn := v.(gen.Connection)
 			if err := conn.Join(c, result.ConnectionID, nil, result.Tail); err != nil {
+				if joinHandshake {
+					status := byte(3)
+					if err.Error() == "connection id mismatch" {
+						status = 1
+					}
+					c.SetWriteDeadline(time.Now().Add(time.Second))
+					c.Write([]byte{status})
+					c.SetWriteDeadline(time.Time{})
+					c.Close()
+					continue
+				}
+				if err.Error() == "connection id mismatch" && n.preferIncomingOnCollision(result.Peer) {
+					n.connections.Delete(result.Peer)
+					conn.Terminate(gen.TerminateReasonNormal)
+
+					log := createLog(n.node.Log().Level(), n.node.dolog)
+					logSource := gen.MessageLogNetwork{
+						Node:     n.node.name,
+						Peer:     result.Peer,
+						Creation: result.PeerCreation,
+					}
+					log.setSource(logSource)
+					newConn, err := a.proto.NewConnection(n.node, result, log)
+					if err != nil {
+						n.node.Log().Warning("unable to create new connection: %s", err)
+						c.Close()
+						continue
+					}
+
+					if existing, err := n.registerConnection(result.Peer, newConn); err != nil {
+						if err == gen.ErrTaken {
+							existing.Terminate(gen.TerminateReasonNormal)
+							n.connections.Delete(result.Peer)
+							if _, err2 := n.registerConnection(result.Peer, newConn); err2 != nil {
+								newConn.Terminate(err2)
+								c.Close()
+								continue
+							}
+						} else {
+							n.node.Log().Warning("unable to register new connection with %s: %s", result.Peer, err)
+							newConn.Terminate(err)
+							c.Close()
+							continue
+						}
+					}
+
+					newConn.Join(c, result.ConnectionID, nil, result.Tail)
+					go n.serve(a.proto, newConn, nil)
+					continue
+				}
 				if err == gen.ErrUnsupported {
 					n.node.Log().Warning("unable to accept connection with %s (join is not supported)",
 						result.Peer)
@@ -1218,6 +1314,19 @@ func (n *network) accept(a *acceptor) {
 				}
 				c.Close()
 			}
+			if joinHandshake {
+				c.SetWriteDeadline(time.Now().Add(time.Second))
+				c.Write([]byte{0})
+				c.SetWriteDeadline(time.Time{})
+			}
+			continue
+		}
+
+		if joinHandshake {
+			c.SetWriteDeadline(time.Now().Add(time.Second))
+			c.Write([]byte{2})
+			c.SetWriteDeadline(time.Time{})
+			c.Close()
 			continue
 		}
 

--- a/testing/tests/002_distributed/t008_simultaneous_connect_test.go
+++ b/testing/tests/002_distributed/t008_simultaneous_connect_test.go
@@ -1,0 +1,164 @@
+package distributed
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"ergo.services/ergo"
+	"ergo.services/ergo/gen"
+)
+
+func TestT8SimultaneousConnect(t *testing.T) {
+	options1 := gen.NodeOptions{}
+	options1.Network.Cookie = "123"
+	options1.Log.DefaultLogger.Disable = true
+
+	options2 := gen.NodeOptions{}
+	options2.Network.Cookie = "123"
+	options2.Log.DefaultLogger.Disable = true
+
+	node1, err := ergo.StartNode("distT8node1@localhost", options1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer node1.Stop()
+
+	node2, err := ergo.StartNode("distT8node2@localhost", options2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer node2.Stop()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	var err1 error
+	var err2 error
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err1 = node1.Network().GetNode(node2.Name())
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err2 = node2.Network().GetNode(node1.Name())
+	}()
+
+	close(start)
+	wg.Wait()
+
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if len(node1.Network().Nodes()) != 1 {
+		t.Fatal("node1 must have exactly one connected node")
+	}
+	if len(node2.Network().Nodes()) != 1 {
+		t.Fatal("node2 must have exactly one connected node")
+	}
+
+	remote1, err := node1.Network().Node(node2.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote2, err := node2.Network().Node(node1.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info1 := remote1.Info()
+	info2 := remote2.Info()
+
+	if info1.Node != node2.Name() {
+		t.Fatal("incorrect remote1 node name")
+	}
+	if info2.Node != node1.Name() {
+		t.Fatal("incorrect remote2 node name")
+	}
+}
+
+func TestT8SimultaneousConnectMany(t *testing.T) {
+	options1 := gen.NodeOptions{}
+	options1.Network.Cookie = "123"
+	options1.Log.DefaultLogger.Disable = true
+
+	options2 := gen.NodeOptions{}
+	options2.Network.Cookie = "123"
+	options2.Log.DefaultLogger.Disable = true
+
+	node1, err := ergo.StartNode("distT8node1many@localhost", options1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer node1.Stop()
+
+	node2, err := ergo.StartNode("distT8node2many@localhost", options2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer node2.Stop()
+
+	const parallel = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	results := make(chan error, parallel*2)
+
+	get1 := func() {
+		defer wg.Done()
+		<-start
+		_, err := node1.Network().GetNode(node2.Name())
+		results <- err
+	}
+	get2 := func() {
+		defer wg.Done()
+		<-start
+		_, err := node2.Network().GetNode(node1.Name())
+		results <- err
+	}
+
+	wg.Add(parallel * 2)
+	for i := 0; i < parallel; i++ {
+		go get1()
+		go get2()
+	}
+
+	close(start)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	close(results)
+
+	for err := range results {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if len(node1.Network().Nodes()) != 1 {
+		t.Fatal("node1 must have exactly one connected node")
+	}
+	if len(node2.Network().Nodes()) != 1 {
+		t.Fatal("node2 must have exactly one connected node")
+	}
+}


### PR DESCRIPTION
Context / Problem

- Under “simultaneous connect” (both nodes dialing each other at the same time) and/or during pool re-dial, the acceptor side can receive a Join attempt for an already-existing logical connection but with a different ConnectionID .
- Today this surfaces as noisy logs like unable to join ... connection id mismatch , and on the dialing side a failed Join can be misinterpreted as a successful recovery of a pool link, causing repeated retries and log storms.
What This PR Changes

- Deterministic connection collision handling (simultaneous connect)
  
  - Adds collision arbitration to converge on a single connection when both sides initiate connections concurrently.
  - When a collision is detected, the code deterministically prefers one side (based on node name ordering) and terminates/replaces the other to prevent “two competing connections” and follow-up Join mismatches.
  - Ensures serve() only unregisters a connection if it still owns the slot (prevents accidental unregister of a newer connection).
- Explicit Join accept/reject signal for pool re-dial (protocol change within EHS Join flow)
  
  - Extends the Join flow to include a 1-byte status immediately after the Accept handshake message.
  - Join() now reads this status and returns a clearer error:
    - join rejected: connection id mismatch
    - join rejected: no existing connection
    - join rejected (generic)
  - The acceptor side writes back the status for Join handshakes (identified by PeerCreation == 0 ), so the dialing side can stop treating a rejected join as a success.
Files Changed

- node/network.go
  - Implements collision arbitration and safer unregister behavior.
  - Adds accept-side Join status responses (success / mismatch / no existing).
- net/handshake/join.go
  - Reads the 1-byte status after Accept in the Join() path and converts it into explicit errors.
- testing/tests/002_distributed/t008_simultaneous_connect_test.go (new)
  - Adds regression tests covering simultaneous connect, including a higher-parallelism case.
Compatibility Notes (Important)

- This PR changes the wire behavior of the Ergo Handshake Join path by requiring an additional 1-byte status after Accept .
- That means it is not backward compatible with older Ergo nodes that don’t send/read this byte during Join() . Mixed-version clusters may fail to re-dial/join pool links until all nodes are upgraded.