### PR TITLE
fix: eliminate data race on application mode and reason fields

### DIFF
--- a/node/application.go
+++ b/node/application.go
@@ -14,13 +14,13 @@ type application struct {
 	node     *node
 	behavior gen.ApplicationBehavior
 	group    lib.Map[gen.PID, bool]
-	mode     gen.ApplicationMode
+	mode     int32
 
 	started int64
 	parent  gen.Atom
 	state   int32
 	stopped chan struct{}
-	reason  error
+	reason  atomic.Value
 }
 
 func (a *application) start(mode gen.ApplicationMode, options gen.ApplicationOptionsExtra) error {
@@ -95,8 +95,8 @@ func (a *application) start(mode gen.ApplicationMode, options gen.ApplicationOpt
 	}
 
 	a.stopped = make(chan struct{})
-	a.node.log.Info("application %s (%s) started", a.spec.Name, a.mode)
-	a.mode = mode
+	atomic.StoreInt32(&a.mode, int32(mode))
+	a.node.log.Info("application %s (%s) started", a.spec.Name, gen.ApplicationMode(atomic.LoadInt32(&a.mode)))
 	a.parent = options.CorePID.Node
 
 	a.started = time.Now().Unix()
@@ -138,7 +138,7 @@ func (a *application) stop(force bool, timeout time.Duration) error {
 	a.registerAppRoute() // new state of the app
 
 	// update mode to prevent triggering 'permantent' mode
-	a.mode = gen.ApplicationModeTemporary
+	atomic.StoreInt32(&a.mode, int32(gen.ApplicationModeTemporary))
 
 	a.group.Range(func(pid gen.PID, _ bool) bool {
 		if force {
@@ -150,9 +150,9 @@ func (a *application) stop(force bool, timeout time.Duration) error {
 	})
 
 	if force {
-		a.reason = gen.TerminateReasonKill
+		a.reason.Store(gen.TerminateReasonKill)
 	} else {
-		a.reason = gen.TerminateReasonShutdown
+		a.reason.Store(gen.TerminateReasonShutdown)
 	}
 
 	select {
@@ -170,7 +170,7 @@ func (a *application) terminate(pid gen.PID, reason error) {
 		return
 	}
 
-	switch a.mode {
+	switch gen.ApplicationMode(atomic.LoadInt32(&a.mode)) {
 	case gen.ApplicationModePermanent:
 		state := atomic.SwapInt32(&a.state, int32(gen.ApplicationStateStopping))
 		if state == int32(gen.ApplicationStateStopping) {
@@ -178,8 +178,8 @@ func (a *application) terminate(pid gen.PID, reason error) {
 			break
 		}
 		a.node.Log().
-			Info("application %s (%s) will be stopped due to termination of %s with reason: %s", a.spec.Name, a.mode, pid, reason)
-		a.reason = reason
+			Info("application %s (%s) will be stopped due to termination of %s with reason: %s", a.spec.Name, gen.ApplicationMode(atomic.LoadInt32(&a.mode)), pid, reason)
+		a.reason.Store(reason)
 		a.group.Range(func(pid gen.PID, _ bool) bool {
 			a.node.SendExit(pid, gen.TerminateReasonShutdown)
 			return true
@@ -190,14 +190,14 @@ func (a *application) terminate(pid gen.PID, reason error) {
 			break
 		}
 		a.node.Log().
-			Info("application %s (%s) will be stopped due to termination of %s with reason: %s", a.spec.Name, a.mode, pid, reason)
+			Info("application %s (%s) will be stopped due to termination of %s with reason: %s", a.spec.Name, gen.ApplicationMode(atomic.LoadInt32(&a.mode)), pid, reason)
 
 		state := atomic.SwapInt32(&a.state, int32(gen.ApplicationStateStopping))
 		if state == int32(gen.ApplicationStateStopping) {
 			// already in stopping
 			break
 		}
-		a.reason = reason
+		a.reason.Store(reason)
 		a.group.Range(func(pid gen.PID, _ bool) bool {
 			a.node.SendExit(pid, gen.TerminateReasonShutdown)
 			return true
@@ -211,8 +211,8 @@ func (a *application) terminate(pid gen.PID, reason error) {
 		return
 	}
 
-	if a.reason == nil {
-		a.reason = gen.TerminateReasonNormal
+	if a.reason.Load() == nil {
+		a.reason.Store(gen.TerminateReasonNormal)
 	}
 
 	old := atomic.SwapInt32(&a.state, int32(gen.ApplicationStateLoaded))
@@ -226,7 +226,7 @@ func (a *application) terminate(pid gen.PID, reason error) {
 	a.started = 0
 	a.parent = ""
 
-	a.node.log.Info("application %s (%s) stopped with reason %s", a.spec.Name, a.mode, a.reason)
+	a.node.log.Info("application %s (%s) stopped with reason %s", a.spec.Name, gen.ApplicationMode(atomic.LoadInt32(&a.mode)), a.reason.Load().(error))
 
 	if lib.Recover() {
 		defer func() {
@@ -238,7 +238,7 @@ func (a *application) terminate(pid gen.PID, reason error) {
 		}()
 	}
 
-	a.behavior.Terminate(a.reason)
+	a.behavior.Terminate(a.reason.Load().(error))
 
 	network := a.node.Network()
 	if network.Mode() != gen.NetworkModeEnabled {
@@ -269,7 +269,7 @@ func (a *application) info() gen.ApplicationInfo {
 	info.Description = a.spec.Description
 	info.Version = a.spec.Version
 	info.Depends = a.spec.Depends
-	info.Mode = a.mode
+	info.Mode = gen.ApplicationMode(atomic.LoadInt32(&a.mode))
 	info.Parent = a.parent
 	info.Uptime = time.Now().Unix() - a.started
 	info.Group = []gen.PID{}
@@ -303,8 +303,8 @@ func (a *application) registerAppRoute() {
 		Name:   a.spec.Name,
 		Weight: a.spec.Weight,
 		Tags:   a.spec.Tags,
-		Mode:   a.mode,
-		State:  gen.ApplicationState(a.state),
+		Mode:   gen.ApplicationMode(atomic.LoadInt32(&a.mode)),
+		State:  gen.ApplicationState(atomic.LoadInt32(&a.state)),
 	}
 	network := a.node.Network()
 	if network.Mode() != gen.NetworkModeEnabled {

--- a/node/node.go
+++ b/node/node.go
@@ -1591,7 +1591,7 @@ func (n *node) ApplicationLoad(app gen.ApplicationBehavior, args ...any) (name g
 		node:     n,
 		behavior: app,
 		state:    int32(gen.ApplicationStateLoaded),
-		mode:     spec.Mode,
+		mode:     int32(spec.Mode),
 	}
 	if _, exist := n.applications.LoadOrStore(spec.Name, a); exist {
 		return spec.Name, gen.ErrTaken


### PR DESCRIPTION
## Summary
Fixes #246

Eliminates the data race between `application.stop()` and `application.terminate()` during node shutdown by using atomic operations for `mode` and `reason` fields.

## Changes
- Changed `mode` field from `gen.ApplicationMode` to `int32` with atomic load/store operations
- Changed `reason` field from `error` to `atomic.Value` for thread-safe access
- Fixed race on `state` field in `registerAppRoute()` by using atomic load
- Fixed log ordering in `start()` to log mode after storing it

## Root Cause
The race occurred because:
1. `stop()` writes to `mode` and `reason` 
2. `terminate()` reads these fields concurrently when child processes exit
3. No synchronization existed between these concurrent accesses