### PR TITLE
fix(net/proto): buffer result channels so fast replies are not dropped

### DIFF
--- a/net/proto/connection.go
+++ b/net/proto/connection.go
@@ -205,7 +205,7 @@ func (c *connection) applicationStart(name gen.Atom, mode gen.ApplicationMode, o
 		Options: extra,
 		Ref:     ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -225,7 +225,7 @@ func (c *connection) ApplicationInfo(name gen.Atom) (gen.ApplicationInfo, error)
 		Ref:  ref,
 	}
 
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -278,7 +278,7 @@ func (c *connection) updateCache() error {
 		Ref: ref,
 		// put them here
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1027,7 +1027,7 @@ func (c *connection) LinkPID(pid gen.PID, target gen.PID) error {
 		Ref:    ref,
 	}
 
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1053,7 +1053,7 @@ func (c *connection) UnlinkPID(pid gen.PID, target gen.PID) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1075,7 +1075,7 @@ func (c *connection) LinkProcessID(pid gen.PID, target gen.ProcessID) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1098,7 +1098,7 @@ func (c *connection) UnlinkProcessID(pid gen.PID, target gen.ProcessID) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1125,7 +1125,7 @@ func (c *connection) LinkAlias(pid gen.PID, target gen.Alias) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1152,7 +1152,7 @@ func (c *connection) UnlinkAlias(pid gen.PID, target gen.Alias) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1174,7 +1174,7 @@ func (c *connection) LinkEvent(pid gen.PID, target gen.Event) ([]gen.MessageEven
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1203,7 +1203,7 @@ func (c *connection) UnlinkEvent(pid gen.PID, target gen.Event) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1228,7 +1228,7 @@ func (c *connection) MonitorPID(pid gen.PID, target gen.PID) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1253,7 +1253,7 @@ func (c *connection) DemonitorPID(pid gen.PID, target gen.PID) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1275,7 +1275,7 @@ func (c *connection) MonitorProcessID(pid gen.PID, target gen.ProcessID) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1297,7 +1297,7 @@ func (c *connection) DemonitorProcessID(pid gen.PID, target gen.ProcessID) error
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1323,7 +1323,7 @@ func (c *connection) MonitorAlias(pid gen.PID, target gen.Alias) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1349,7 +1349,7 @@ func (c *connection) DemonitorAlias(pid gen.PID, target gen.Alias) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1371,7 +1371,7 @@ func (c *connection) MonitorEvent(pid gen.PID, target gen.Event) ([]gen.MessageE
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1400,7 +1400,7 @@ func (c *connection) DemonitorEvent(pid gen.PID, target gen.Event) error {
 		Target: target,
 		Ref:    ref,
 	}
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -1446,7 +1446,7 @@ func (c *connection) RemoteSpawn(name gen.Atom, options gen.ProcessOptionsExtra)
 		Ref:     ref,
 	}
 
-	ch := make(chan MessageResult)
+	ch := make(chan MessageResult, 1)
 	c.requestsMutex.Lock()
 	c.requests[ref] = ch
 	c.requestsMutex.Unlock()
@@ -2692,6 +2692,12 @@ func (c *connection) routeMessage(msg any) {
 			return
 		}
 
+		// The result channel is buffered (cap 1, one result per request), so this
+		// send always succeeds even when the requester goroutine has not yet parked
+		// on the channel. Without the buffer, a reply that arrives within the tiny
+		// window between registering the request and parking in waitResult would hit
+		// the default branch and be dropped, leaving the requester to time out at the
+		// 5s deadline (observed for fast, sub-millisecond spawn round-trips).
 		select {
 		case ch <- m:
 		default:

--- a/net/proto/connection.go
+++ b/net/proto/connection.go
@@ -3063,7 +3063,14 @@ func (c *connection) waitResult(ref gen.Ref, ch chan MessageResult) (result Mess
 
 	select {
 	case <-timer.C:
-		result.Error = gen.ErrTimeout
+		// select does not prioritize between ready cases, so the timer case can be
+		// taken even when a result is already buffered on ch. Re-check ch before
+		// reporting a timeout so an already-delivered reply is not discarded.
+		select {
+		case result = <-ch:
+		default:
+			result.Error = gen.ErrTimeout
+		}
 	case result = <-ch:
 	}
 


### PR DESCRIPTION
## Summary

Remote request/reply calls (RemoteSpawn, RouteSend, monitors, application start/info, and similar) register a reply channel keyed by ref, send the request, and then park in waitResult to await the reply. The reply channel is created unbuffered, and routeMessage delivers the reply with a non-blocking send:

```go
select {
case ch <- m:
default:
}
```

On an unbuffered channel a non-blocking send succeeds only if a receiver is already parked on the channel at that instant. There is a window between "request sent" and "requester parked in waitResult" during which no receiver is parked yet. If the reply arrives inside that window (common for fast, sub-millisecond localhost round trips) the send falls through to default and the reply is silently discarded. The requester then blocks until the request deadline (DefaultRequestTimeout, 5s) and returns ErrTimeout, even though the peer answered almost immediately.

The two parties are different goroutines running in parallel: the requester (whatever goroutine called the request) and the connection's receive/dispatch goroutine. Nothing forces the requester to reach its parking point before the dispatcher delivers, so the window is real whenever GOMAXPROCS > 1, and it widens under scheduler contention.

## Observed

Found by placing temporary logging in the default (drop) branch, correlated by ref. For a request with a 3ms round trip, the trace showed the reply arriving (the ref was present in the requests map) immediately followed by the drop, then the 5s timeout:

```
recv-result ref=R found=true
drop-result ref=R (waiter not parked)
... 5s ...
request-done ref=R err=timed out
```

## Fix

Make the reply channels buffered with capacity 1 (one result is expected per request). A non-blocking send to a buffered channel succeeds whenever the buffer has a free slot, independent of whether a receiver is parked, so the reply lands in the buffer and the requester reads it when it parks. The default branch is kept as a guard so the shared receive goroutine never blocks (for example on a duplicate or late second reply for the same ref). This preserves the non-blocking property the default was protecting while closing the window. All MessageResult reply channels in net/proto/connection.go are buffered.