### PR TITLE
fix(net/proto): recreate send flusher when a pool lane re-dials

### DIFF
--- a/net/proto/connection.go
+++ b/net/proto/connection.go
@@ -1519,7 +1519,17 @@ func (c *connection) Join(conn net.Conn, id string, dial gen.NetworkDial, tail [
 				if err != nil {
 					continue
 				}
+				// Install the new socket for both reading (pi.connection, used by
+				// serve below) and sending (pi.fl). The flusher wraps a specific
+				// net.Conn, so it must be recreated for the new socket — otherwise
+				// the send path keeps writing into the dead original socket and
+				// those messages are silently lost. Guard the swap with the pool
+				// mutex since send reads pi.fl under it.
+				c.pool_mutex.Lock()
 				pi.connection = nc
+				pi.fl = lib.NewFlusher(nc)
+				c.pool_mutex.Unlock()
+				c.log.Warning("re-dialed pool lane to %s after connection loss; recreated send flusher", nc.RemoteAddr())
 				tail = t
 
 				goto re
@@ -3015,6 +3025,7 @@ func (c *connection) send(buf *lib.Buffer, order uint8, compression gen.Compress
 	}
 
 	var pi *pool_item
+	var fl io.Writer
 	c.pool_mutex.RLock()
 	l := len(c.pool)
 	if l == 0 {
@@ -3029,6 +3040,9 @@ func (c *connection) send(buf *lib.Buffer, order uint8, compression gen.Compress
 		n := int(order) % l
 		pi = c.pool[n]
 	}
+	// Capture the flusher under the lock: a re-dial can swap pi.fl, and the
+	// flusher must match the live socket.
+	fl = pi.fl
 	c.pool_mutex.RUnlock()
 
 	atomic.AddUint64(&c.messagesOut, 1)
@@ -3039,7 +3053,7 @@ func (c *connection) send(buf *lib.Buffer, order uint8, compression gen.Compress
 	// c.transitOut++
 	// if buf.Len() < protoFragmentSize {
 
-	pi.fl.Write(buf.B)
+	fl.Write(buf.B)
 	lib.ReleaseBuffer(buf)
 	return nil
 


### PR DESCRIPTION
## Summary

A pooled node connection holds several TCP lanes to the same peer. Each lane's pool_item is created with both a connection (used for reading) and a flusher bound to that same socket (used for sending):

```go
pi := &pool_item{
    connection: conn,
    fl:         lib.NewFlusher(conn),
}
```

When a lane's socket dies, the dialing side re-dials and installs the new socket for reading, but never rebuilds the flusher:

```go
re:
    c.serve(pi.connection, tail)   // returns when the socket dies
    if dial != nil {
        nc, t, err := dial(dsn, id)
        ...
        pi.connection = nc          // new socket, used for reading
        goto re                     // pi.fl still wraps the dead socket
    }
```

After the re-dial the lane is half open: reads use the new socket, but send (which writes through pi.fl) keeps writing into the dead original socket. Those bytes never reach the peer, so any message routed onto that lane is silently lost and a request on that lane times out at the deadline. This is permanent for the lifetime of the lane, not transient, because nothing rebinds pi.fl. It affects the dialing side only; the accepting side replaces the whole pool_item, and its flusher, when the peer reconnects.

Found by code inspection while investigating a related timeout. It triggers whenever a pool lane re-dials, which does not happen on stable connections but will on flaky or multi node links.

## Fix

Rebuild the lane's flusher for the new socket on re-dial, under the pool mutex, and read the flusher under the same mutex in send so the swap is race free:

```go
c.pool_mutex.Lock()
pi.connection = nc
pi.fl = lib.NewFlusher(nc)
c.pool_mutex.Unlock()
```